### PR TITLE
Fix extra rotations of the weapon rack showing up

### DIFF
--- a/resources/assets/maltiezfirearms/blocktypes/weaponrack.json
+++ b/resources/assets/maltiezfirearms/blocktypes/weaponrack.json
@@ -9,7 +9,7 @@
   },
   "class": "CombatOverhaul:GenericDisplayBlock",
   "entityClass": "CombatOverhaul:GenericDisplayBlockEntity",
-  "creativeinventory": {"general": ["*"], "maltiezfirearms": ["*-east"], "clutter": ["*-rusty-east"]},
+  "creativeinventory": {"general": ["*-east"], "maltiezfirearms": ["*-east"], "clutter": ["*-rusty-east"]},
   "shapeByType": {
     "*-north": {"base": "blocks/weaponrack", "rotateY": 0},
     "*-east": {"base": "blocks/weaponrack", "rotateY": 270},


### PR DESCRIPTION
Fixes the rotations of the weapon rack showing up as discrete items in the creative menu and handbook