### PR TITLE
Handbook cleanup pass

### DIFF
--- a/resources/assets/maltiezfirearms/blocktypes/pistolstand.json
+++ b/resources/assets/maltiezfirearms/blocktypes/pistolstand.json
@@ -5,7 +5,10 @@
   "attributes": {
     "inventorySize": 1,
     "inventoryTransformAttribute": "inPistolstandTransform",
-    "rotateByType": {"*-north": {"y": 0}, "*-east": {"y": 270}, "*-west": {"y": 90}, "*-south": {"y": 180}}
+    "rotateByType": {"*-north": {"y": 0}, "*-east": {"y": 270}, "*-west": {"y": 90}, "*-south": {"y": 180}},
+    "handbook": {
+      "groupBy": ["pistolstand-*"]
+    }
   },
   "class": "CombatOverhaul:GenericDisplayBlock",
   "entityClass": "CombatOverhaul:GenericDisplayBlockEntity",

--- a/resources/assets/maltiezfirearms/blocktypes/powderbarrel.json_
+++ b/resources/assets/maltiezfirearms/blocktypes/powderbarrel.json_
@@ -24,7 +24,10 @@
       "collapsed3": "sounds/block/largechestclose"
     },
     "variantByGroup": "side",
-    "variantByGroupInventory": null
+    "variantByGroupInventory": null,
+    "handbook": {
+      "groupBy": ["powderbarrel-*"]
+    }
   },
   "behaviors": [{"name": "Lockable"}, {"name": "Container"}],
   "entityBehaviors": [{"name": "Animatable"}],

--- a/resources/assets/maltiezfirearms/blocktypes/vice.json
+++ b/resources/assets/maltiezfirearms/blocktypes/vice.json
@@ -5,7 +5,10 @@
   "attributes": {
     "inventorySize": 1,
     "inventoryTransformAttribute": "inViceTransform",
-    "rotateByType": {"*-north": {"y": 0}, "*-east": {"y": 270}, "*-west": {"y": 90}, "*-south": {"y": 180}}
+    "rotateByType": {"*-north": {"y": 0}, "*-east": {"y": 270}, "*-west": {"y": 90}, "*-south": {"y": 180}},
+    "handbook": {
+      "groupBy": ["vice-*"]
+    }
   },
   "class": "CombatOverhaul:GenericDisplayBlock",
   "entityClass": "CombatOverhaul:GenericDisplayBlockEntity",

--- a/resources/assets/maltiezfirearms/blocktypes/wallmount.json
+++ b/resources/assets/maltiezfirearms/blocktypes/wallmount.json
@@ -8,7 +8,10 @@
   "attributes": {
     "inventorySize": 1,
     "inventoryTransformAttribute": "inWallmountTransform",
-    "rotateByType": {"*-north": {"y": 0}, "*-east": {"y": 270}, "*-west": {"y": 90}, "*-south": {"y": 180}}
+    "rotateByType": {"*-north": {"y": 0}, "*-east": {"y": 270}, "*-west": {"y": 90}, "*-south": {"y": 180}},
+    "handbook": {
+      "groupBy": ["wallmount-*"]
+    }
   },
   "class": "CombatOverhaul:GenericDisplayBlock",
   "entityClass": "CombatOverhaul:GenericDisplayBlockEntity",

--- a/resources/assets/maltiezfirearms/blocktypes/wallmountdouble.json
+++ b/resources/assets/maltiezfirearms/blocktypes/wallmountdouble.json
@@ -8,7 +8,10 @@
   "attributes": {
     "inventorySize": 2,
     "inventoryTransformAttribute": "inWallmountTransform",
-    "rotateByType": {"*-north": {"y": 0}, "*-east": {"y": 270}, "*-west": {"y": 90}, "*-south": {"y": 180}}
+    "rotateByType": {"*-north": {"y": 0}, "*-east": {"y": 270}, "*-west": {"y": 90}, "*-south": {"y": 180}},
+    "handbook": {
+      "groupBy": ["wallmountdouble-*"]
+    }
   },
   "class": "CombatOverhaul:GenericDisplayBlock",
   "entityClass": "CombatOverhaul:GenericDisplayBlockEntity",

--- a/resources/assets/maltiezfirearms/blocktypes/weaponrack.json
+++ b/resources/assets/maltiezfirearms/blocktypes/weaponrack.json
@@ -5,7 +5,10 @@
   "attributes": {
     "inventorySize": 1,
     "inventoryTransformAttribute": "inWeaponrackTransform",
-    "rotateByType": {"*-north": {"y": 0}, "*-east": {"y": 270}, "*-west": {"y": 90}, "*-south": {"y": 180}}
+    "rotateByType": {"*-north": {"y": 0}, "*-east": {"y": 270}, "*-west": {"y": 90}, "*-south": {"y": 180}},
+    "handbook": {
+      "groupBy": ["weaponrack-*"]
+    }
   },
   "class": "CombatOverhaul:GenericDisplayBlock",
   "entityClass": "CombatOverhaul:GenericDisplayBlockEntity",

--- a/resources/assets/maltiezfirearms/itemtypes/bayonet.json
+++ b/resources/assets/maltiezfirearms/itemtypes/bayonet.json
@@ -12,7 +12,10 @@
     "groundStorageTransform": {"translation": {"x": 0.3, "y": 0.04, "z": 0.4}, "rotation": {"x": 1, "y": -110, "z": 169}, "origin": {"x": 0, "y": 0, "z": 0}},
     "knifeHitBlockAnimation": "knifecut",
     "knifeHitEntityAnimation": "knifestab",
-    "musketRenderVariantByType": {"*-plug-plain": 2, "*-plug-decorated": 3, "*-socket-plain": 4, "*-socket-decorated": 5}
+    "musketRenderVariantByType": {"*-plug-plain": 2, "*-plug-decorated": 3, "*-socket-plain": 4, "*-socket-decorated": 5},
+    "handbook": {
+      "groupBy": ["bayonet-*"]
+    }
   },
   "behaviors": [
     {

--- a/resources/assets/maltiezfirearms/itemtypes/cockinglever.json
+++ b/resources/assets/maltiezfirearms/itemtypes/cockinglever.json
@@ -5,7 +5,10 @@
   "shape": {"base": "maltiezfirearms:cocking-lever"},
   "textures": {"metal": {"base": "game:block/metal/plate/{metal}"}},
   "attributes": {
-    "groundStorageTransform": {"translation": {"x": 0.6, "y": 0, "z": 0.5}, "rotation": {"x": 1, "y": -64, "z": 90}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 1.22}
+    "groundStorageTransform": {"translation": {"x": 0.6, "y": 0, "z": 0.5}, "rotation": {"x": 1, "y": -64, "z": 90}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 1.22},
+    "handbook": {
+      "groupBy": ["cockinglever-*"]
+    }
   },
   "behaviors": [
     {

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/arquebus.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/arquebus.json
@@ -48,6 +48,9 @@
       "Rotate": true,
       "ScaleXYZ": {"X": 0.81, "Y": 0.81, "Z": 0.81}
     },
+    "handbook": {
+      "groupBy": ["firearm-arquebus-*"]
+    },
     "BulletDamageMultiplier": 1.375,
     "BulletDamageStrength": 6,
     "BulletTransform": {"translation": {"x": -2.2, "y": 0.2, "z": -2.2}, "rotation": {"x": 0, "y": 0, "z": 0}, "scale": 0.3},

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/blunderbuss-flintlock.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/blunderbuss-flintlock.json
@@ -45,6 +45,9 @@
       "Rotate": true,
       "ScaleXYZ": {"X": 0.81, "Y": 0.81, "Z": 0.81}
     },
+    "handbook": {
+      "groupBy": ["firearm-blunderbuss-steel"]
+    },
     "BulletDamageMultiplier": 1,
     "BulletDamageStrength": 5,
     "BulletTransform": {"translation": {"x": -2.2, "y": 0.2, "z": -2.2}, "rotation": {"x": 0, "y": 0, "z": 0}, "scale": 0.3},

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/blunderbuss.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/blunderbuss.json
@@ -48,6 +48,9 @@
       "Rotate": true,
       "ScaleXYZ": {"X": 0.81, "Y": 0.81, "Z": 0.81}
     },
+    "handbook": {
+      "groupBy": ["firearm-blunderbuss-iron", "firearm-blunderbuss-meteoriciron", "firearm-blunderbuss-rusted"]
+    },
     "BulletDamageMultiplier": 1,
     "BulletDamageStrength": 4,
     "BulletTransform": {"translation": {"x": -2.2, "y": 0.2, "z": -2.2}, "rotation": {"x": 0, "y": 0, "z": 0}, "scale": 0.3},

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/carbine.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/carbine.json
@@ -25,6 +25,9 @@
     "groundStorageTransform": {"translation": {"x": 0.55, "y": 0.44, "z": 0.75}, "rotation": {"x": 100, "y": 4, "z": -101}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.81},
     "inWallmountTransform": {"translation": {"x": -0.38, "y": -0.03, "z": -0.04}, "rotation": {"x": 90, "y": -84, "z": 90}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.81},
     "inWeaponrackTransform": {"translation": {"x": 0, "y": 0.02, "z": 0.08}, "rotation": {"x": 82, "y": 0, "z": 0}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.81},
+    "handbook": {
+      "groupBy": ["firearm-carbine-*"]
+    },
     "BulletDamageMultiplier": 1,
     "BulletDamageStrength": 8,
     "BulletTransform": {"translation": {"x": -2.2, "y": 0.2, "z": -2.2}, "rotation": {"x": 0, "y": 0, "z": 0}, "scale": 0.3},

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/musket.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/musket.json
@@ -36,6 +36,9 @@
     "groundStorageTransform": {"translation": {"x": 0.55, "y": 0.44, "z": 0.75}, "rotation": {"x": 98, "y": 4, "z": -101}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.81},
     "inWallmountTransform": {"translation": {"x": -0.6, "y": -0.06, "z": -0.04}, "rotation": {"x": 90, "y": -83, "z": 90}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.81},
     "inWeaponrackTransform": {"translation": {"x": 0, "y": 0.02, "z": 0.08}, "rotation": {"x": 82, "y": 0, "z": 0}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.81},
+    "handbook": {
+      "groupBy": ["firearm-musket-steel"]
+    },
     "BulletDamageMultiplier": 1.63,
     "BulletDamageStrength": 9,
     "BulletTransform": {"translation": {"x": -2.2, "y": 0.2, "z": -2.2}, "rotation": {"x": 0, "y": 0, "z": 0}, "scale": 0.3},

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/parts/barrel.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/parts/barrel.json
@@ -12,6 +12,9 @@
       "*-blunderbuss-*": {"translation": {"x": 0.5, "y": -0.1, "z": 0.78}, "rotation": {"x": 99, "y": 0, "z": 0}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.8},
       "*-carbine-*": {"translation": {"x": 0.5, "y": -0.12, "z": 0.76}, "rotation": {"x": 98, "y": 0, "z": 0}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.8},
       "*-musket-*": {"translation": {"x": 0.5, "y": -0.19, "z": 0.66}, "rotation": {"x": 99, "y": 0, "z": 0}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.8}
+    },
+    "handbook": {
+      "groupBy": ["barrel-{weapon}-*"]
     }
   },
   "behaviors": [

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/parts/lock.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/parts/lock.json
@@ -13,6 +13,9 @@
       "*-wheellock-*": {"translation": {"x": 0.4, "y": 0.04, "z": 0.4}, "rotation": {"x": 1, "y": -110, "z": 89}, "origin": {"x": 0, "y": 0, "z": 0}},
       "*-matchlock-*": {"translation": {"x": 0.4, "y": 0.11, "z": 0.5}, "rotation": {"x": 0, "y": -139, "z": 158}, "origin": {"x": 0, "y": 0, "z": 0}},
       "*-flintlock-*": {"translation": {"x": 0.3, "y": 0.02, "z": 0.45}, "rotation": {"x": -2, "y": -110, "z": 88}, "origin": {"x": 0, "y": 0, "z": 0}}
+    },
+    "handbook": {
+      "groupBy": ["lock-{type}-*"]
     }
   },
   "behaviors": [

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/parts/ramrod.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/parts/ramrod.json
@@ -14,6 +14,9 @@
       "*-arquebus-*": {"translation": {"x": 0.5, "y": 0.1, "z": 0.8}, "rotation": {"x": 99, "y": 0, "z": 0}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.8},
       "*-carbine-*": {"translation": {"x": 0.5, "y": -0.1, "z": 0.82}, "rotation": {"x": 98, "y": 0, "z": 0}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.8},
       "*-musket-*": {"translation": {"x": 0.5, "y": -0.2, "z": 0.72}, "rotation": {"x": 99, "y": 0, "z": 0}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.8}
+    },
+    "handbook": {
+      "groupBy": ["ramrod-{weapon}-*"]
     }
   },
   "behaviors": [

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/pistol-flintlock.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/pistol-flintlock.json
@@ -25,6 +25,9 @@
     "toolrackTransform": {"translation": {"x": 1.05, "y": 0.55, "z": 0.5}, "rotation": {"x": -1, "y": 95, "z": -90}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 1.34},
     "groundStorageTransform": {"translation": {"x": 0.7, "y": 0.04, "z": 0.7}, "rotation": {"x": 0, "y": 57, "z": 90}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.8},
     "inPistolstandTransform": {"translation": {"x": -0.25, "y": -0.05, "z": 0}, "rotation": {"x": 90, "y": -96, "z": 103}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.81},
+    "handbook": {
+      "groupBy": ["firearm-pistol-steel"]
+    },
     "BulletDamageMultiplier": 1,
     "BulletDamageStrength": 5,
     "BulletTransform": {"translation": {"x": -2.2, "y": 0.2, "z": -2.2}, "rotation": {"x": 0, "y": 0, "z": 0}, "scale": 0.3},

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/pistol.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/pistol.json
@@ -25,6 +25,10 @@
     "toolrackTransform": {"translation": {"x": 1.05, "y": 0.55, "z": 0.5}, "rotation": {"x": -1, "y": 95, "z": -90}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 1.34},
     "groundStorageTransform": {"translation": {"x": 0.7, "y": 0.04, "z": 0.7}, "rotation": {"x": 0, "y": 57, "z": 90}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.8},
     "inPistolstandTransform": {"translation": {"x": -0.25, "y": -0.05, "z": 0}, "rotation": {"x": 90, "y": -96, "z": 103}, "origin": {"x": 0, "y": 0, "z": 0}, "scale": 0.81},
+    "handbook": {
+      "groupBy": ["firearm-pistol-tinbronze", "firearm-pistol-bismuthbronze", "firearm-pistol-blackbronze", "firearm-pistol-tarnished"]
+    },
+
     "BulletDamageMultiplier": 1,
     "BulletDamageStrength": 4,
     "BulletTransform": {"translation": {"x": -2.2, "y": 0.2, "z": -2.2}, "rotation": {"x": 0, "y": 0, "z": 0}, "scale": 0.3},

--- a/resources/assets/maltiezfirearms/itemtypes/firearms/superimposed.json
+++ b/resources/assets/maltiezfirearms/itemtypes/firearms/superimposed.json
@@ -45,6 +45,9 @@
       "Rotate": true,
       "ScaleXYZ": {"X": 0.81, "Y": 0.81, "Z": 0.81}
     },
+    "handbook": {
+      "groupBy": ["firearm-superimposed-*"]
+    },
     "BulletDamageMultiplier": 1,
     "BulletDamageStrength": 5,
     "BulletTransform": {"translation": {"x": -2.2, "y": 0.2, "z": -2.2}, "rotation": {"x": 0, "y": 0, "z": 0}, "scale": 0.3},


### PR DESCRIPTION
Adds "groupBy" handbook attributes to every item with variants in the firearms mod. This collapses variants of material into those slideshow scrolling icons in the handbook:
<img width="827" height="164" alt="image" src="https://github.com/user-attachments/assets/26a40ca6-02d6-442d-8d59-0f12739dfcc5" />